### PR TITLE
fix: ensure unit tests run in separate directory

### DIFF
--- a/my-plugin/generators/my-generator.spec.ts
+++ b/my-plugin/generators/my-generator.spec.ts
@@ -4,6 +4,7 @@ import { Tree, readProjectConfiguration } from '@nx/devkit';
 import { myGeneratorGenerator } from './my-generator';
 import { MyGeneratorGeneratorSchema } from './schema';
 import { E2eTestRunner } from '@nx/angular/generators';
+import { TempFs } from '../testing-utils/temp-fs';
 
 // This is in the nx/angular repo unit test for the Angular application generator, it doesn't help
 jest.mock('@nx/devkit', () => {
@@ -20,12 +21,22 @@ jest.mock('@nx/devkit', () => {
 
 describe('my-generator generator', () => {
   let tree: Tree;
+  let tempFs: TempFs;
+  let cwd = process.cwd();
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-    // This is in the nx/angular repo unit test for the Angular application generator, it doesn't help
-    tree.write('.gitignore', '');
+    tree = createTreeWithEmptyWorkspace();
+    tempFs = new TempFs('test');
+    tempFs.createFileSync("nx.json", `{"$schema": "./node_modules/nx/schemas/nx-schema.json", "plugins": []}`)
+    tree.write("nx.json", `{"$schema": "./node_modules/nx/schemas/nx-schema.json", "plugins": []}`)
+    tree.root = tempFs.tempDir
+    process.chdir(tree.root);
   });
+
+  afterEach(() => {
+    tempFs.reset();
+    process.chdir(cwd);
+  })
 
   it('none', async () => {
     const options: MyGeneratorGeneratorSchema = { name: 'plain-app',e2eTestRunner: E2eTestRunner.None };

--- a/my-plugin/testing-utils/temp-fs.ts
+++ b/my-plugin/testing-utils/temp-fs.ts
@@ -1,0 +1,97 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { joinPathFragments } from '@nx/devkit';
+import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
+
+type NestedFiles = {
+  [fileName: string]: string;
+};
+
+export class TempFs {
+  readonly tempDir: string;
+
+  private previousWorkspaceRoot: string;
+
+  constructor(private dirname: string, overrideWorkspaceRoot = true) {
+    this.tempDir = realpathSync(mkdtempSync(join(tmpdir(), this.dirname)));
+    this.previousWorkspaceRoot = workspaceRoot;
+
+    if (overrideWorkspaceRoot) {
+      setWorkspaceRoot(this.tempDir);
+    }
+  }
+
+  async createFiles(fileObject: NestedFiles) {
+    await Promise.all(
+      Object.keys(fileObject).map(async (path) => {
+        await this.createFile(path, fileObject[path]);
+      })
+    );
+  }
+
+  createFilesSync(fileObject: NestedFiles) {
+    for (let path of Object.keys(fileObject)) {
+      this.createFileSync(path, fileObject[path]);
+    }
+  }
+
+  async createFile(filePath: string, content: string) {
+    const dir = joinPathFragments(this.tempDir, dirname(filePath));
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+    await writeFile(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  createFileSync(filePath: string, content: string) {
+    let dir = joinPathFragments(this.tempDir, dirname(filePath));
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  async readFile(filePath: string): Promise<string> {
+    return await readFile(joinPathFragments(this.tempDir, filePath), 'utf-8');
+  }
+
+  removeFileSync(filePath: string): void {
+    unlinkSync(joinPathFragments(this.tempDir, filePath));
+  }
+
+  appendFile(filePath: string, content: string) {
+    appendFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+
+  writeFile(filePath: string, content: string) {
+    writeFileSync(joinPathFragments(this.tempDir, filePath), content);
+  }
+  renameFile(oldPath: string, newPath: string) {
+    renameSync(
+      joinPathFragments(this.tempDir, oldPath),
+      joinPathFragments(this.tempDir, newPath)
+    );
+  }
+
+  cleanup() {
+    rmSync(this.tempDir, { recursive: true, force: true });
+    setWorkspaceRoot(this.previousWorkspaceRoot);
+  }
+
+  reset() {
+    rmSync(this.tempDir, { recursive: true, force: true });
+    mkdirSync(this.tempDir, { recursive: true });
+  }
+}


### PR DESCRIPTION
The issue occurs because the process itself is running within the context of Nx Workspace which has a Crystal plugin set up for playwright-e2e.
This interferes with the unit testing process when the generators under test perform actions that require loading the crystal plugin.

The solution is to ensure the unit tests are run in separate directory than the Nx workspace. 
This contains a copy of one of the utils Nx has internally for helping in this regard: TempFs.


